### PR TITLE
Fix a javascript fatal error when "today" or "clear" word contains apost...

### DIFF
--- a/Zebra_Form.php
+++ b/Zebra_Form.php
@@ -1458,10 +1458,10 @@ class Zebra_Form
                     if (is_array($this->form_properties['language']['months_abbr'])) $control->attributes['months_abbr'] = $this->form_properties['language']['months_abbr'];
 
                     // use the caption from the language file for the "Clear date" button
-                    $control->attributes['lang_clear_date'] = $this->form_properties['language']['clear_date'];
+                    $control->attributes['lang_clear_date'] = addslashes($this->form_properties['language']['clear_date']);
 
                     // if the "Today" button is not disabled use the caption from the language file
-                    if ($control->attributes['show_select_today'] === null) $control->attributes['show_select_today'] = $this->form_properties['language']['today'];
+                    if ($control->attributes['show_select_today'] === null) $control->attributes['show_select_today'] =$ addslashes(this->form_properties['language']['today']);
 
                     $properties = '';
 


### PR DESCRIPTION
...rophes in the language used

When "Today" or "Clear" word contains apostrophes in selected language like in French : "Aujourd'hui" for today, a fatal javascript exception was caught because the generated javascript code was not correct (missing slashes).

Probably not the best solution to fix this because it may add unnecessary slashes.
In addition, I don't really know if this should be fixed in Datepicker (client side) or in Zebra_Form (server side), I did with what I had. Working with a minimized version of Datepicker would have been much more difficult.

Note that there is no fix here for months and days abreviations because I don't know if it's buggy too and it would probably require a bit more work (like a loop if it were done in server side).
